### PR TITLE
Limit Requests Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests <=2.29.0
+requests<2.30.0
 jsonschema
 google-crc32c

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests <=2.29.0
 jsonschema
 google-crc32c


### PR DESCRIPTION
The python `requests` package recently released v2.30, which contains a change that `getm` is not compatible with. (see [release notes here](https://requests.readthedocs.io/en/latest/community/updates/#release-history) -- the breaking change was the upgrade to urllib3). This PR simply ensures that `getm` is only ever installed with a compatible `requests` package.

While there were a number of ways to solve this problem, this is the "lightest touch" approach that is the least likely to interfere with anyone's current workflow. 